### PR TITLE
Throw exceptions for invalid formulas

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -60,7 +60,7 @@ directives = {
 
 setup(
     name="xlfparser",
-    version="0.0.1",
+    version="0.0.2",
     packages=["xlfparser"],
     author="Tony Roberts",
     author_email="tony@pyxll.com",

--- a/python/tests/test_xlfparser.py
+++ b/python/tests/test_xlfparser.py
@@ -1,3 +1,4 @@
+import pytest
 from xlfparser import tokenize, stringify, build_ast, Token
 
 
@@ -86,3 +87,21 @@ def test_ast_builder():
 
     ast = build_ast(tokenize("={FUNC(-1, 2*3, 4%, (5 / 6))}"))
     assert str(ast) == "{ FUNC( - 1 , 2 * 3 , 4 % , ( 5 / 6 ) ) }"
+
+
+def test_invalid_formulas():
+    with pytest.raises(RuntimeError) as e:
+        tokenize("=}")
+    assert "Mismatched braces" in str(e)
+
+    with pytest.raises(RuntimeError) as e:
+        tokenize("={1,2,3}}")
+    assert "Mismatched braces" in str(e)
+
+    with pytest.raises(RuntimeError) as e:
+        tokenize("=)")
+    assert "Mismatched parentheses" in str(e)
+
+    with pytest.raises(RuntimeError) as e:
+        tokenize("=foo())")
+    assert "Mismatched parentheses" in str(e)

--- a/python/xlfparser/_xlfparser.cpp
+++ b/python/xlfparser/_xlfparser.cpp
@@ -3,12 +3,14 @@
 /* BEGIN: Cython Metadata
 {
     "distutils": {
-        "depends": [],
+        "depends": [
+            "C:\\github\\tonyroberts\\xlfparser\\python\\include\\xlfparser.h"
+        ],
         "extra_compile_args": [
             "/std:c++17"
         ],
         "include_dirs": [
-            "C:\\github\\xlfparser\\python\\include"
+            "C:\\github\\tonyroberts\\xlfparser\\python\\include"
         ],
         "language": "c++",
         "name": "xlfparser._xlfparser",

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -436,3 +436,11 @@ TEST_CASE("Arrays with inner functions using different locale are parsed correct
     CHECK(result[15].type() == Token::Type::Array);
     CHECK(result[15].subtype() == Token::Subtype::Stop);
 }
+
+TEST_CASE("Invalid formula expressions throw an exception", "[xlfparser]")
+{
+    REQUIRE_THROWS_WITH(tokenize(std::string_view("=}")), Contains("Mismatched braces"));
+    REQUIRE_THROWS_WITH(tokenize(std::string_view("={1,2,3}}")), Contains("Mismatched braces"));
+    REQUIRE_THROWS_WITH(tokenize(std::string_view("=)")), Contains("Mismatched parentheses"));
+    REQUIRE_THROWS_WITH(tokenize(std::string_view("=foo())")), Contains("Mismatched parentheses"));
+}


### PR DESCRIPTION
Mismatched closing braces and parentheses could cause undefined behaviour when attempting to read the top of an empty stack.